### PR TITLE
Add option to specify start LocalDateTime in nextRunList()

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,27 @@ println(builder.nextRunList()) // 10 is a default list size
     2050-01-29T05:06:20,
     2050-01-29T05:06:30
 ]
-*/ 
+*/
+```
+You can also specify the `LocalDateTime` from which the list of `LocalDateTime`s will start generating.
+```kotlin
+val builder = KCron.parseAndBuild("0/10 5-25 5,12 ? * 7#5 2050", WeekDays.Sunday)
+val start = LocalDateTime(2050, 1, 29, 5, 5, 15)
+println(builder.nextRunList(10, start))
+/* Result:
+[
+    2050-01-29T05:05:20,
+    2050-01-29T05:05:30,
+    2050-01-29T05:05:40,
+    2050-01-29T05:05:50,
+    2050-01-29T05:06,
+    2050-01-29T05:06:10,
+    2050-01-29T05:06:20,
+    2050-01-29T05:06:30,
+    2050-01-29T05:06:40,
+    2050-01-29T05:06:50
+]
+*/
 ```
 ***Days of week and months can be defined in a parsed expression as numbers as well as short names***
 ```kotlin

--- a/src/commonMain/kotlin/com/ucasoft/kcron/builders/Builder.kt
+++ b/src/commonMain/kotlin/com/ucasoft/kcron/builders/Builder.kt
@@ -82,15 +82,14 @@ class Builder(firstDayOfWeek: WeekDays = WeekDays.Monday) {
         return this
     }
 
-    fun nextRunList(maxCount: Int = 10) : List<LocalDateTime> {
-        val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+    fun nextRunList(maxCount: Int = 10, start: LocalDateTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())) : List<LocalDateTime> {
         val result = mutableListOf<LocalDateTime>()
-        for (year in (partBuilders.getValue(CronPart.Years) as YearsBuilder).years.filter { y -> y >= now.year }) {
-            for (month in (partBuilders.getValue(CronPart.Months) as MonthsBuilder).months.filter { m -> m >= now.monthNumber || year > now.year}) {
-                for (day in calculateDays(year, month, (partBuilders.getValue(CronPart.DaysOfWeek) as DaysOfWeekBuilder).daysOfWeek, (partBuilders.getValue(CronPart.Days) as DaysBuilder).days, now)) {
-                    for (hour in (partBuilders.getValue(CronPart.Hours) as HoursBuilder).hours.filter { h -> h >= now.hour || day > now.dayOfMonth || month > now.monthNumber || year > now.year }) {
-                        for (minute in (partBuilders.getValue(CronPart.Minutes) as MinutesBuilder).minutes.filter { m -> m >= now.minute || hour > now.hour || day > now.dayOfMonth || month > now.monthNumber || year > now.year }) {
-                            for (seconds in (partBuilders.getValue(CronPart.Seconds) as SecondsBuilder).seconds.filter { s -> s > now.second || minute > now.minute || hour > now.hour || day > now.dayOfMonth || month > now.monthNumber || year > now.year }) {
+        for (year in (partBuilders.getValue(CronPart.Years) as YearsBuilder).years.filter { y -> y >= start.year }) {
+            for (month in (partBuilders.getValue(CronPart.Months) as MonthsBuilder).months.filter { m -> m >= start.monthNumber || year > start.year}) {
+                for (day in calculateDays(year, month, (partBuilders.getValue(CronPart.DaysOfWeek) as DaysOfWeekBuilder).daysOfWeek, (partBuilders.getValue(CronPart.Days) as DaysBuilder).days, start)) {
+                    for (hour in (partBuilders.getValue(CronPart.Hours) as HoursBuilder).hours.filter { h -> h >= start.hour || day > start.dayOfMonth || month > start.monthNumber || year > start.year }) {
+                        for (minute in (partBuilders.getValue(CronPart.Minutes) as MinutesBuilder).minutes.filter { m -> m >= start.minute || hour > start.hour || day > start.dayOfMonth || month > start.monthNumber || year > start.year }) {
+                            for (seconds in (partBuilders.getValue(CronPart.Seconds) as SecondsBuilder).seconds.filter { s -> s > start.second || minute > start.minute || hour > start.hour || day > start.dayOfMonth || month > start.monthNumber || year > start.year }) {
                                 result.add(LocalDateTime(year, month, day, hour, minute, seconds))
                                 if (result.size == maxCount) {
                                     return result

--- a/src/commonTest/kotlin/com/ucasoft/kcron/builders/BuilderTests.kt
+++ b/src/commonTest/kotlin/com/ucasoft/kcron/builders/BuilderTests.kt
@@ -1,5 +1,6 @@
 package com.ucasoft.kcron.builders
 
+import com.ucasoft.kcron.KCron
 import com.ucasoft.kcron.common.DayOfWeekGroups
 import com.ucasoft.kcron.common.WeekDays
 import com.ucasoft.kcron.extensions.*
@@ -127,7 +128,7 @@ class BuilderTests {
         val builder = Builder(WeekDays.Monday)
         builder.anyYears().months(1).days(1).hours(0).minutes(0).seconds(0)
         println(builder.expression)
-        var result = builder.nextRunList(2, start = LocalDateTime(2050, 2, 1, 0, 0))
+        val result = builder.nextRunList(2, start = LocalDateTime(2050, 2, 1, 0, 0))
         assertEquals(LocalDate(2051, 1, 1), result[0].date)
         assertEquals(LocalDate(2052, 1, 1), result[1].date)
     }

--- a/src/commonTest/kotlin/com/ucasoft/kcron/builders/BuilderTests.kt
+++ b/src/commonTest/kotlin/com/ucasoft/kcron/builders/BuilderTests.kt
@@ -121,4 +121,14 @@ class BuilderTests {
         assertEquals("0 0 0 ? 1 THU#5 2099", builder.expression)
         assertEquals(expected.plusDays(28), builder.nextRun)
     }
+
+    @Test
+    fun buildManyWithCustomStartTime() {
+        val builder = Builder(WeekDays.Monday)
+        builder.anyYears().months(1).days(1).hours(0).minutes(0).seconds(0)
+        println(builder.expression)
+        var result = builder.nextRunList(2, start = LocalDateTime(2050, 2, 1, 0, 0))
+        assertEquals(LocalDate(2051, 1, 1), result[0].date)
+        assertEquals(LocalDate(2052, 1, 1), result[1].date)
+    }
 }

--- a/src/commonTest/kotlin/com/ucasoft/kcron/builders/BuilderTests.kt
+++ b/src/commonTest/kotlin/com/ucasoft/kcron/builders/BuilderTests.kt
@@ -1,10 +1,11 @@
 package com.ucasoft.kcron.builders
 
-import com.ucasoft.kcron.KCron
 import com.ucasoft.kcron.common.DayOfWeekGroups
 import com.ucasoft.kcron.common.WeekDays
 import com.ucasoft.kcron.extensions.*
-import kotlinx.datetime.*
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull


### PR DESCRIPTION
I added the option for the library user to specify for themselves the `LocalDateTime` they want to use instead of always having `now()`.